### PR TITLE
MDS ontology: labels instead of class IDs

### DIFF
--- a/mds-elasticsearch-indexing-provider/CHANGELOG.md
+++ b/mds-elasticsearch-indexing-provider/CHANGELOG.md
@@ -1,7 +1,16 @@
 # Changelog for elasticsearch-indexing-provider
 All notable changes to this project will be documented in this file.
 
-## [feature/fixUriOrModelClassHandling] - 11.05.2022
+## [feature/improveMdsLabelDisplaying] - 11.05.2022
+### Added
+- Mapping from MDS ontology URIs (e.g. `cat:RoadworksRoadConditions`) to the labels linked with a `rdfs:label` property.
+  - This can be used, to map the IDs of an incoming `mds:DataCategory`, `mds:DataSubcategory` or `mds:TransportationMode` to its label.
+
+### Changed
+- In ElasticSearch, the fields for the MDS properties don't contain the IDs (i.e. URIs) of the classes like `cat:RoadworksRoadConditions` anymore. This is replaced by the labels annotated to the respective RDF representation of the class.
+- For cases where multiple data categories are given, they are split by `,` and then mapped to the respective labels.
+
+## [development] - 11.05.2022
 ### Changed
 - ElasticSearch fields for `publisher`, `maintainer`, `curator` and `sovereign` are replaced by:
   - `publisherAsUri` and `publisherAsObject`


### PR DESCRIPTION
Display content of MDS properties in ElasticSearch with the labels instead of the class IDs.